### PR TITLE
fix: Update release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,6 +13,8 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  packages: write
+  deployments: read
 
 name: release-please
 


### PR DESCRIPTION
This PR adds necessary permissions: `packages` and `deployments` to enable the release-please workflow with GITHUB_TOKEN.